### PR TITLE
增加进度条触发高度，以达到缩略图框范围

### DIFF
--- a/src/renderer/components/PlayingView/TimeProgressBar.vue
+++ b/src/renderer/components/PlayingView/TimeProgressBar.vue
@@ -172,7 +172,7 @@ export default {
   bottom: 0;
   left: 0;
   width: 100%;
-  height: 20px;
+  height: 30px;
   -webkit-app-region: no-drag;
 
   .progress-container:hover {


### PR DESCRIPTION
增加进度条触发高度，以达到缩略图框范围，增进操作手感。